### PR TITLE
chore: rename project-blue to klasa-core across the code

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dirigeants/project-blue.git"
+    "url": "git+https://github.com/dirigeants/core.git"
   },
   "devDependencies": {
     "@ava/typescript": "^1.1.1",
@@ -37,9 +37,9 @@
   "author": "dirigeants",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dirigeants/project-blue/issues"
+    "url": "https://github.com/dirigeants/core/issues"
   },
-  "homepage": "https://github.com/dirigeants/project-blue#readme",
+  "homepage": "https://github.com/dirigeants/core#readme",
   "dependencies": {
     "@klasa/bitfield": "^0.0.2",
     "@klasa/cache": "^0.0.3",

--- a/src/lib/client/BaseClient.ts
+++ b/src/lib/client/BaseClient.ts
@@ -10,7 +10,7 @@ export interface BaseClientOptions {
 }
 
 /**
- * The Project-Blue Base Client used to wrap the Discord API
+ * The Klasa-Core Base Client used to wrap the Discord API
  */
 export class BaseClient extends EventEmitter {
 
@@ -25,7 +25,7 @@ export class BaseClient extends EventEmitter {
 	public options: BaseClientOptions;
 
 	/**
-	 * @param options All of your preferences on how Project-Blue should work for you
+	 * @param options All of your preferences on how Klasa-Core should work for you
 	 */
 	public constructor(options: Partial<BaseClientOptions>) {
 		super();

--- a/src/lib/client/Client.ts
+++ b/src/lib/client/Client.ts
@@ -106,7 +106,7 @@ export const enum ClientEvents {
 }
 
 /**
- * The Project-Blue Client used to wrap the discord api
+ * The Klasa-Core Client used to wrap the discord api
  */
 export class Client extends BaseClient {
 
@@ -171,7 +171,7 @@ export class Client extends BaseClient {
 	public readonly actions: ActionStore;
 
 	/**
-	 * @param options All of your preferences on how Project-Blue should work for you
+	 * @param options All of your preferences on how Klasa-Core should work for you
 	 */
 	public constructor(options: Partial<ClientOptions> = {}) {
 		super(options);
@@ -289,7 +289,7 @@ export class Client extends BaseClient {
 	/**
 	 * The plugin symbol to be used in external packages
 	 */
-	public static readonly plugin: unique symbol = Symbol('ProjectBluePlugin');
+	public static readonly plugin: unique symbol = Symbol('KlasaCorePlugin');
 
 	/**
 	 * The plugins to be used when creating a Client instance

--- a/src/lib/client/WebhookClient.ts
+++ b/src/lib/client/WebhookClient.ts
@@ -3,7 +3,7 @@ import { Webhook } from '../caching/structures/Webhook';
 import { Cache } from '@klasa/cache';
 
 /**
- * The Project-Blue Webhook Client used to manipulate webhooks
+ * The Klasa-Core Webhook Client used to manipulate webhooks
  */
 export class WebhookClient extends BaseClient {
 

--- a/src/lib/util/Extender.ts
+++ b/src/lib/util/Extender.ts
@@ -26,7 +26,7 @@ import { VoiceState } from '../caching/structures/guilds/VoiceState';
 import { ClientUser } from '../caching/structures/ClientUser';
 
 /**
- * The extender class that allows the extension of built-in structures from Project-Blue and plugins.
+ * The extender class that allows the extension of built-in structures from Klasa-Core and plugins.
  */
 class Extender extends Cache<keyof ExtenderStructures, ExtenderStructures[keyof ExtenderStructures]> {
 
@@ -72,8 +72,8 @@ class Extender extends Cache<keyof ExtenderStructures, ExtenderStructures[keyof 
 	 * @param key The name of the structure to be extended
 	 * @param fn A callback returning the extended class
 	 * @example
-	 * const { extender } = require('@klasa/project-blue');
-	 * const { Settings } = require('@klasa/project-red');
+	 * const { extender } = require('@klasa/core');
+	 * const { Settings } = require('klasa');
 	 *
 	 * extender.extend('TextChannel', (TextChannel) => class extends TextChannel {
 	 *

--- a/src/lib/util/bitfields/Activity.ts
+++ b/src/lib/util/bitfields/Activity.ts
@@ -5,7 +5,7 @@ export type ActivityResolvable = keyof typeof Activity.FLAGS | number | BitField
 /* eslint-disable no-bitwise */
 
 /**
- * Handles Activity BitFields in Project-Blue
+ * Handles Activity BitFields in Klasa-Core
  */
 export class Activity extends BitField<ActivityResolvable> {
 

--- a/src/lib/util/bitfields/MessageFlags.ts
+++ b/src/lib/util/bitfields/MessageFlags.ts
@@ -5,7 +5,7 @@ export type MessageFlagsResolvable = keyof typeof MessageFlags.FLAGS | number | 
 /* eslint-disable no-bitwise */
 
 /**
- * Handles MessageFlags BitFields in Project-Blue
+ * Handles MessageFlags BitFields in Klasa-Core
  */
 export class MessageFlags extends BitField<MessageFlagsResolvable> {
 

--- a/src/lib/util/bitfields/Permissions.ts
+++ b/src/lib/util/bitfields/Permissions.ts
@@ -5,7 +5,7 @@ export type PermissionsResolvable = keyof typeof Permissions.FLAGS | number | Bi
 /* eslint-disable no-bitwise */
 
 /**
- * Handles Permission BitFields in Project-Blue
+ * Handles Permission BitFields in Klasa-Core
  */
 export class Permissions extends BitField<PermissionsResolvable> {
 

--- a/src/lib/util/bitfields/Speaking.ts
+++ b/src/lib/util/bitfields/Speaking.ts
@@ -5,7 +5,7 @@ export type SpeakingResolvable = keyof typeof Speaking.FLAGS | number | BitField
 /* eslint-disable no-bitwise */
 
 /**
- * Handles Speaking BitFields in Project-Blue
+ * Handles Speaking BitFields in Klasa-Core
  */
 export class Speaking extends BitField<SpeakingResolvable> {
 

--- a/src/lib/util/bitfields/UserFlags.ts
+++ b/src/lib/util/bitfields/UserFlags.ts
@@ -5,7 +5,7 @@ export type UserFlagsResolvable = keyof typeof UserFlags.FLAGS | number | BitFie
 /* eslint-disable no-bitwise */
 
 /**
- * Handles UserFlags BitFields in Project-Blue
+ * Handles UserFlags BitFields in Klasa-Core
  */
 export class UserFlags extends BitField<UserFlagsResolvable> {
 


### PR DESCRIPTION
Noticed some remaining references to the old name in the code. Renamed them all accordingly.