### PR TITLE
feat: add lastPinTimestamp to DMChannel, update lastPinTimestamp

### DIFF
--- a/src/actions/channels/CHANNEL_PINS_UPDATE.ts
+++ b/src/actions/channels/CHANNEL_PINS_UPDATE.ts
@@ -14,6 +14,8 @@ export default class CoreAction extends Action {
 		const channel = guild ? guild.channels.get(data.d.channel_id) : this.client.dms.get(data.d.channel_id);
 		if (!channel || !isTextBasedChannel(channel)) return;
 
+		channel.lastPinTimestamp = data.d.last_pin_timestamp ?? null;
+
 		this.client.emit(this.clientEvent, channel, this.parseDate(data.d.last_pin_timestamp));
 	}
 

--- a/src/lib/caching/structures/channels/DMChannel.ts
+++ b/src/lib/caching/structures/channels/DMChannel.ts
@@ -44,6 +44,12 @@ export class DMChannel extends Channel {
 	public lastMessageID!: string | null;
 
 	/**
+	 * When the last pinned message was pinned.
+	 * @since 0.0.3
+	 */
+	public lastPinTimestamp!: string | null;
+
+	/**
 	 * The recipients of the DM.
 	 * @since 0.0.1
 	 */
@@ -151,6 +157,7 @@ export class DMChannel extends Channel {
 		// eslint-disable-next-line dot-notation
 		this.recipients = (data.recipients as APIUserData[]).map(user => this.client.users['_add'](user));
 		this.lastMessageID = data.last_message_id as string | null;
+		this.lastPinTimestamp = data.last_pin_timestamp ?? null;
 		return this;
 	}
 


### PR DESCRIPTION
- Adds missing `lastPinTimestamp` property to DMChannel.
- Updates `lastPinTimestamp` when CHANNEL_PINS_UPDATE action runs.